### PR TITLE
Subsystem specific baseURL's

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -69,6 +69,12 @@
 				<cfset arguments.path = getDirectoryFromPath( arguments.path ) />
 				<cfset omitIndex = true />
 			</cfif>
+		<cfelseif arguments.path eq "useSubsystemBaseURL">
+			<cfset arguments.path = variables.framework.subsystem[ getSubsystem( arguments.action ) ].baseURL />
+			<cfif variables.framework.SESOmitIndex>
+				<cfset arguments.path = getDirectoryFromPath( arguments.path ) />
+				<cfset omitIndex = true />
+			</cfif>
 		</cfif>
 		
 		<cfif find( '?', arguments.action ) and arguments.queryString is ''>


### PR DESCRIPTION
With this simple modification to the buildURL function, it allows for subsystems to use different baseURL's without having to pass a path on every buildURL().  This shouldn't break any existing applications, and in the future I imagine that there would be other framework variables that could be assigned at the subsystem level instead of the global level and those settings could be in the variables.framework.subsystem[ subsystem ] scope.  I originally had this setup to be variables.framework[ subsystem ] but realized that some subsystems might be named the same as framework variables like "home".
