### PR TITLE
Develop

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1063,7 +1063,7 @@ component {
 			var md = { extends = baseMetadata };
 			do {
 				md = md.extends;
-				var implicitSetters = structKeyExists( md, 'accessors' ) && isBoolean( md.accessors ) && md.accessors;
+				var implicitSetters = ( structKeyExists( md, 'persistent' )  && isBoolean( md.persistent ) && md.persistent || structKeyExists( md, 'accessors' ) && isBoolean( md.accessors ) && md.accessors );
 				if ( structKeyExists( md, 'properties' ) ) {
 					// due to a bug in ACF9.0.1, we cannot use var property in md.properties,
 					// instead we must use an explicit loop index... ugh!


### PR DESCRIPTION
Checks persistent flag on the cfc metadata as well accessors flag. 
Hopefully I've sent the correct pull request this time... :)

I've just downloaded the latest version from the develop branch and the populate method stopped working and didn't populate any of the properties in my persistent entity. This change fixes it for me (ACF 9.01 Windows 7). Thanks!
