### PR TITLE
Ensure request.context is available to onError handler

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -537,6 +537,12 @@ component {
 			// setup the new controller action, based on the error action:
 			structDelete( request, 'controllers' );
 			request.action = variables.framework.error;
+			
+			// ensure request.context is available
+			if ( ! structKeyExists ( request, 'context' ) ) {
+			    request.context = { };
+			}
+			
 			setupRequestWrapper( false );
 			onRequest( '' );
 		} catch ( any e ) {


### PR DESCRIPTION
If an error occurs early enough in the application lifecycle there might not be a request.context in the onError handler, this causes an error when the error handler controller method is called.  This change initializes an empty request.context if it does not yet exist in the onError handler.
