### PR TITLE
buildURL queryString struct enhancement

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -63,7 +63,8 @@ component {
 	 *	buildURL() should be used from views to construct urls when using subsystems or
 	 *	in order to provide a simpler transition to using subsystems in the future
 	 */
-	public string function buildURL( string action, string path = variables.magicBaseURL, string queryString = '' ) {
+	public string function buildURL( string action = '', string path = variables.magicBaseURL, any queryString = '' ) {
+		if ( action == '' ) action = getFullyQualifiedAction();
 		if ( path == variables.magicBaseURL ) path = getBaseURL();
 		var omitIndex = false;
 		if ( path == 'useSubsystemConfig' ) {
@@ -86,6 +87,17 @@ component {
 				path = getDirectoryFromPath( path );
 				omitIndex = true;
 			}
+		}
+		// if queryString is a struct, massage it into a string
+		if ( isStruct( queryString ) && structCount( queryString ) ) {
+			var q = '';
+			for( var key in queryString ) {
+				q &= '#urlEncodedFormat( key )#=#urlEncodedFormat( queryString[ key ] )#&';
+			}
+			queryString = q;
+		}
+		else if ( !isSimpleValue( queryString ) ) {
+			queryString = '';
 		}
 		if ( queryString == '' ) {
 			// extract query string from action section:


### PR DESCRIPTION
Addresses #109 to accept a struct in the queryString argument to buildURL.  I also defaulted action to an empty string, in which case the current action is assumed.  This goes hand in hand with the reason for a struct based queryString, which in my environment is often current-action hierarchy drill down.

This makes buildURL more flexible, yet should break no current implementations.
