### PR TITLE
Set FW/1 defaults (if key missing) when fatal error thrown

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -561,7 +561,21 @@ component {
 			if ( !structKeyExists( request, 'context' ) ) {
 			    request.context = { };
 			}
-			
+			if ( !structKeyExists( request, 'base' ) ) {
+				if ( structKeyExists( variables, 'framework' ) && structKeyExists( variables.framework, 'base' ) ) {
+					request.base = variables.framework.base;
+				} else {
+					request.base = '';
+				}
+			}
+			if ( !structKeyExists( request, 'cfcbase' ) ) {
+				if ( structKeyExists( variables, 'framework' ) && structKeyExists( variables.framework, 'cfcbase' ) ) {
+					request.cfcbase = variables.framework.cfcbase;
+				} else {
+					request.cfcbase = '';
+				}
+			}
+						
 			setupRequestWrapper( false );
 			onRequest( '' );
 		} catch ( any e ) {


### PR DESCRIPTION
When you get a fatal error in the application start up, then you sometimes see an error thrown by FW/1 such as "FW/1 key [BASE] doesn't exist in struct". An example of when this can happen is with an ORM enabled app where the datasource does not exist.

Thanks! :)
