### PR TITLE
Develop

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -561,6 +561,20 @@ component {
 			if ( !structKeyExists( request, 'context' ) ) {
 			    request.context = { };
 			}
+			if ( !structKeyExists( request, 'base' ) ) {
+				if ( structKeyExists( variables, 'framework' ) && structKeyExists( variables.framework, 'base' ) ) {
+					request.base = variables.framework.base;
+				} else {
+					request.base = '';
+				}
+			}
+			if ( !structKeyExists( request, 'cfcbase' ) ) {
+				if ( structKeyExists( variables, 'framework' ) && structKeyExists( variables.framework, 'cfcbase' ) ) {
+					request.cfcbase = variables.framework.cfcbase;
+				} else {
+					request.cfcbase = '';
+				}
+			}
 			
 			setupRequestWrapper( false );
 			onRequest( '' );


### PR DESCRIPTION
When you get a fatal error in the application start up, then you sometimes see an error thrown by FW/1 such as "FW/1 key [BASE] doesn't exist in struct". An example of when this can happen is with an ORM enabled app where the datasource does not exist.

Hopefully I've got the commit and pull request right this time!

Thanks Sean :)
