### PR TITLE
CGI.PATH_INFO fix for CF10 and allow for end of string rule in routes

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1497,7 +1497,8 @@ component {
 			}
 			if ( route == '*' ) {
 				route = '/';
-			} else if ( right( route, 1 ) != '/' ) {
+			} else if ( right( route, 1 ) != '/' && right( route, 1 ) != '$' ) {
+				// only add the closing backslash if last position is not already a "/" or a "$" to respect regex end of string
 				route &= '/';
 			}
 		} else {
@@ -1512,8 +1513,9 @@ component {
 			target = replace( target, placeholder, chr(92) & n );
 			++n;
 		}
-		// add trailing match/back reference:
-		route &= '(.*)';
+		// add trailing match/back reference: if last character is not "$" to respect regex end of string
+		if (right( route, 1 ) != '$')
+			route &= '(.*)';
 		target &= chr(92) & n;
 		// end of preprocessing section
 		if ( !len( path ) || right( path, 1) != '/' ) path &= '/';


### PR DESCRIPTION
Hello Sean,

I believe I did this right this time. Thank you for your patience and help. This pull request includes the path_info fix, so fw/1 works in CF10 and I added the ability to respect end of string rule in routes.

Thank you,
Giancarlo Gomez
