### PR TITLE
Update to ProcessRouteMatch to allow for additional regex functionality

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1494,12 +1494,14 @@ component {
 			route = '/';
 		}
 		if ( !len( target ) || right( target, 1) != '/' ) target &= '/';
-		// walk for :var and replace with ([^/]*) in route and back reference in target:
+		// walk for self defined (regex) and :var -  replace :var with ([^/]*) in route and back reference in target:
 		var n = 1;
-		var placeholders = rematch( ':[^/]+', route );
+		var placeholders = rematch( '(:[^/]+)|(\([^\)]+)', route );
 		for ( var placeholder in placeholders ) {
-			route = replace( route, placeholder, '([^/]*)' );
-			target = replace( target, placeholder, chr(92) & n );
+			if(left(placeholder,1) == ":"){
+				route = replace( route, placeholder, '([^/]*)' );
+				target = replace( target, placeholder, chr(92) & n );
+			}
 			++n;
 		}
 		// add trailing match/back reference: if last character is not "$" to respect regex end of string


### PR DESCRIPTION
This update lets you write a route that can let you define your own regex to evaluate and update the back reference accordingly.

i.e. a route like "^/(blog|forum|forums)/:action/$", "/forum::action/"

would give you a target of /forum:\1/\2 meaning if you pass /blog/post/ if would translate to /forum:blog/post when what you really wanted it /forum:post/

so now in the placeholders I added to check for (([^)]+) and within the loop it only process the replacement for :var and for anything else just increases the back reference number value
