### PR TITLE
Add top to the WriteDump

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1134,7 +1134,7 @@ component {
 	}
 	
 	private void function dumpException( any exception ) {
-		writeDump( var = exception, label = 'Exception' );
+		writeDump( var = exception, label = 'Exception', top = 2 );
 	}
 	
 	private void function ensureNewFrameworkStructsExist() {


### PR DESCRIPTION
Add top to the WriteDump to limit the levels of an exception that get shown. 

ORM (aka the vietnam of computer science!) exception dumps can be huge and potentially cause Java Heap errors.
