### PR TITLE
Stop onRequestEnd firing for unhandled paths

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -770,6 +770,8 @@ component {
 				REFindNoCase( '^(' & variables.framework.unhandledPathRegex & ')', targetPath ) ) {		
 			structDelete(this, 'onRequest');
 			structDelete(variables, 'onRequest');
+			structDelete(this, 'onRequestEnd');
+			structDelete(variables, 'onRequestEnd');			
             if ( !variables.framework.unhandledErrorCaught ) {
 			    structDelete(this, 'onError');
 			    structDelete(variables, 'onError');


### PR DESCRIPTION
onRequestend is firing for unhandled paths, this has the unwanted side effect of causing trace data to be rendered in non-framework requests. fixes #154
