### PR TITLE
Update org/corfield/framework.cfc

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1534,8 +1534,12 @@ component {
 				detail='The view method should not be called prior to the completion of the service execution phase.' );
 		}
 		var response = '';
-		savecontent variable="response" {
-			include '#viewPath#';
+		try {
+			savecontent variable="response" {
+				include '#viewPath#';
+			}
+		} catch ( any e ) {
+			onMissingView( request.context );
 		}
 		return response;
 	}


### PR DESCRIPTION
It is possible when using variables.fw.view("sub:this/that"); that the view may not exist.  The onmissingview method was not being called under this condition.
