### PR TITLE
Avoid stripping non-slash characters from beginning of path

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1926,7 +1926,11 @@ component {
                 // we use .split() to handle empty items in pathInfo - we fallback to listToArray() on
                 // any system that doesn't support .split() just in case (empty items won't work there!)
                 if ( len( pathInfo ) > 1 ) {
-                    pathInfo = right( pathInfo, len( pathInfo ) - 1 ).split( '/' );
+                    // Strip leading "/" if present.
+                    if ( left( pathInfo, 1 ) EQ '/' ) {
+                        pathInfo = right( pathInfo, len( pathInfo ) - 1 );
+                    }
+                    pathInfo = pathInfo.split( '/' );
                 } else {
                     pathInfo = arrayNew( 1 );
                 }


### PR DESCRIPTION
Avoids bug on ACF10 that was turning the URL "/main/home"
into the action "ain.home"

Noted on a fresh CF10 install on OS X , testing out a project that worked fine under CF9, using urlrewriter. Only URLs like '/app/main/home' were impacted. Same version of urlrewriter, same project code, web.xml's as close as possible considering 9 vs. 10.

Looked for root cause of URL difference, couldn't find it - this seems like a safe enough change, however. With this, both my CF9 & CF10 versions of the app work.
