### PR TITLE
Enable usingSubsystems if subsystem-dependent setting is used.

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1794,7 +1794,7 @@ component {
 			}
 		}
 		if ( !structKeyExists(variables.framework, 'usingSubsystems') ) {
-			variables.framework.usingSubsystems = false;
+			variables.framework.usingSubsystems = structKeyExists(variables.framework,'defaultSubsystem') || structKeyExists(variables.framework,'sitewideLayoutSubsystem');
 		}
 		if ( !structKeyExists(variables.framework, 'defaultSubsystem') ) {
 			variables.framework.defaultSubsystem = 'home';


### PR DESCRIPTION
If either `defaultSubsystem` or `sitewideLayoutSubsystem` are set the default value for `usingSubsystems` is changed to true.

Fixes issue #148
