### PR TITLE
add oMM check to injectFramework

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1497,7 +1497,7 @@ component {
 	
 	private void function injectFramework( any cfc ) {
 		var args = { };
-		if ( structKeyExists( cfc, 'setFramework' ) ) {
+		if ( structKeyExists( cfc, 'setFramework' ) || structKeyExists( cfc, 'onMissingMethod' ) ) {
 			args.framework = this;
 			// allow alternative spellings
 			args.fw = this;


### PR DESCRIPTION
If the instance of the controller the framework gets from the bean factory is actually a proxy, for example when using aop, we need to check for onMissingMethod in injectFramework() to allow it to function correctly.
