### PR TITLE
Fix old typo; be more consistent about injecting the framework

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1400,10 +1400,8 @@ component {
 				if ( !structKeyExists( cache[ types ], componentKey ) ) {
 					if ( usingSubsystems() && hasSubsystemBeanFactory( subsystem ) && getSubsystemBeanFactory( subsystem ).containsBean( beanName ) ) {
 						cfc = getSubsystemBeanFactory( subsystem ).getBean( beanName );
-						if ( type == 'controller' ) injectFramework( cfc );
 					} else if ( !usingSubsystems() && hasDefaultBeanFactory() && getDefaultBeanFactory().containsBean( beanName ) ) {
 						cfc = getDefaultBeanFactory().getBean( beanName );
-						if ( type == 'controller' ) injectFramework( cfc );
 					} else {
 						if ( type == 'controller' && section == variables.magicApplicationController ) {
 							// treat this (Application.cfc) as a controller:
@@ -1428,6 +1426,7 @@ component {
 						}
 					}
 					if ( isObject( cfc ) ) {
+                        if ( type == 'controller' ) injectFramework( cfc );
 						cache[ types ][ componentKey ] = cfc;
 					}
 				}


### PR DESCRIPTION
This restores the original session key value (to what it was in the 1.x stream) - which no one seems to have noticed!

It also injects the framework into "all" controllers in a more consistent manner.
