### PR TITLE
Fixes #169 by throwing an exception if framework.home is specified and y...

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1829,7 +1829,13 @@ component {
 		if ( !structKeyExists(variables.framework, 'siteWideLayoutSubsystem') ) {
 			variables.framework.siteWideLayoutSubsystem = 'common';
 		}
-		if ( !structKeyExists(variables.framework, 'home') ) {
+		if ( structKeyExists(variables.framework, 'home') ) {
+            if (usingSubsystems()) {
+                if ( !find( variables.framework.subsystemDelimiter, variables.framework.home ) ) {
+                    raiseException( type = "FW1.configuration.home", message = "You are using subsystems but framework.home does not specify a subsystem.", detail = "You should set framework.home to #variables.framework.defaultSubsystem##variables.framework.subsystemDelimiter##variables.framework.home#" );
+                }
+            }
+        } else {
 			if (usingSubsystems()) {
 				variables.framework.home = variables.framework.defaultSubsystem & variables.framework.subsystemDelimiter & variables.framework.defaultSection & '.' & variables.framework.defaultItem;
 			} else {


### PR DESCRIPTION
...ou are using subsystems, but you do not specify a subsystem in the value.

This may be a breaking change for a few people but if they are relying on the default behavior, it is inconsistent and they may run into strange bugs, so this is doing them a favor. Hopefully the exception should be clear enough.
