### PR TITLE
changed variables.framework.routes reference in processRoutes() to getRoutes()

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1661,7 +1661,7 @@ component {
 	}
 
 	private string function processRoutes( string path ) {
-		for ( var routePack in variables.framework.routes ) {
+		for ( var routePack in getRoutes() ) {
 			for ( var route in routePack ) {
 				if ( route != 'hint' ) {
 					var routeMatch = processRouteMatch( route, routePack[ route ], path );


### PR DESCRIPTION
As per the message board, I changed the explicit reference to `variables.framework.routes` in `processRoutes()` to a `getRoutes()` method call. This should make it easier to add routes to a request  in a more dynamic fashion. 
