### PR TITLE
Correct MIME type for renderData JSON response

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1770,7 +1770,7 @@ component {
         var statusCode = request._fw1.renderData.statusCode;
         switch ( type ) {
         case 'json':
-            contentType = 'application/javascript; charset=utf-8';
+            contentType = 'application/json; charset=utf-8';
             out = serializeJSON( data );
             break;
         case 'xml':


### PR DESCRIPTION
The correct MIME type for a JSON response should be `application/json`. When it's `application/javascript` jQuery (for example) does not automagically detect and deserialize.
