### PR TITLE
Remove unneccesary log line in test case

### DIFF
--- a/tests/frameworkErrorTest.cfc
+++ b/tests/frameworkErrorTest.cfc
@@ -46,7 +46,6 @@
         
     private void function exceptionCapture( any exception)
     {
-        writeLog(text="Exception: #exception.message#");
         request.capturedException = arguments.exception;
     }
 }


### PR DESCRIPTION
It was causing an error on Railo 4.2, and was not required for
anything but initial debugging of the exception logging anyway.
