### PR TITLE
clearing out factories on app reload

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -2037,6 +2037,8 @@ component {
 				// application is already loaded, just reset the cache and trigger re-initialization of subsystems
 				application[variables.framework.applicationKey].cache = frameworkCache;
 				application[variables.framework.applicationKey].subsystems = { };
+				application[variables.framework.applicationKey].subsystemFactories = { };
+				structDelete( application[variables.framework.applicationKey], "factory" );
 			} else {
 				// must be first request so we need to set up the entire structure
 				isReload = false;


### PR DESCRIPTION
(resubmit - on correct branch this time!)

These two lines ensure that the bean factory is cleared from the application scope on app reload. Feel free to merge or ignore as you see fit! :)

https://groups.google.com/forum/#!topic/framework-one/wCEHMA_ni_I
