### PR TITLE
remove leading whitespace on calls to renderData()

### DIFF
--- a/org/corfield/framework.cfc
+++ b/org/corfield/framework.cfc
@@ -1923,9 +1923,9 @@ component {
                    detail = 'renderData() called with unknown type: ' & type );
             break;
         }
-        getPageContext().getResponse().setStatus( statusCode );        
+        getPageContext().getResponse().setStatus( statusCode );
         // set the content type header portably:
-        getPageContext().getResponse().setContentType( contentType );        
+        getPageContext().getResponse().setContentType( contentType );
         // clear response whitespace (Adobe CF)
         getPageContext().getCfOutput().clearAll();
         return out;


### PR DESCRIPTION
In Adobe CF, if "whitespace management enabled" is not checked, which may often be the case, calls to renderData will output many lines of whitespace before the desired content (json, xml, plain text).

To address this situation I have added the following line just before the return statement in the renderDataWithContentType() method:
getPageContext().getCfOutput().clearAll();

Sorry for the two commits, the first one was adding the patch, and the second one is removing some extra spaces I accidentally introduced into the source.
