### PR TITLE
Adding logic to support function expressions for the onLoad listener

### DIFF
--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -491,6 +491,8 @@ component {
             } else if ( isSimpleValue( head.listener ) &&
                         containsBean( head.listener ) ) {
                 getBean( head.listener ).onLoad( this );
+            } else if ( listFirst(server.coldfusion.productVersion) >= 10 && isClosure(head.listener) ) {
+				head.listener(this);
             } else {
                 throw "invalid onLoad listener registered: #head.listener.toString()#";
             }

--- a/tests/OnLoadTest.cfc
+++ b/tests/OnLoadTest.cfc
@@ -41,6 +41,20 @@ component extends="mxunit.framework.TestCase" {
         assertTrue( bf.getBean( "listener" ).isLoaded() );
     }
 
+     function shouldBeAbleToUseFunctionExpressionListener() {
+        
+        if (listFirst(server.coldfusion.productVersion) >= 10) {
+
+            var onLoadHasFired = false;
+            var bf = new framework.ioc("/tests/model").onLoad(function(beanFactory){
+                    onLoadHasFired = true;
+                });
+            var q = bf.containsBean( "foo" );
+            assertTrue( onLoadHasFired );    
+        }
+        
+    }
+
     private void function loader( any factory ) {
         ++application.loadCount;
     }


### PR DESCRIPTION
Also added tests for this feature. I ran the tests on recent railo - although I did test the little bit of logic separately on cf9 and 10.

This pull request does rely on version sniffing to ensure that isClosure() is available and supported (ACF 10+).  I did not see anything else in the code that used version sniffing in this manner - if there is a better way to achieve this let me know and I will resubmit.
