### PR TITLE
OnLoadEvent function expressions. 

### DIFF
--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -484,15 +484,13 @@ component {
     private void function onLoadEvent() {
         var head = variables.listeners;
         while ( isStruct( head ) ) {
-            if ( isCustomFunction( head.listener ) ) {
+            if ( isCustomFunction( head.listener ) OR ( listFirst( server.coldfusion.productVersion ) >= 10 && isClosure( head.listener ) ) ) {
                 head.listener( this );
             } else if ( isObject( head.listener ) ) {
                 head.listener.onLoad( this );
             } else if ( isSimpleValue( head.listener ) &&
                         containsBean( head.listener ) ) {
                 getBean( head.listener ).onLoad( this );
-            } else if ( listFirst(server.coldfusion.productVersion) >= 10 && isClosure(head.listener) ) {
-				head.listener(this);
             } else {
                 throw "invalid onLoad listener registered: #head.listener.toString()#";
             }

--- a/tests/OnLoadTest-cf10.cfm
+++ b/tests/OnLoadTest-cf10.cfm
@@ -1,0 +1,6 @@
+var onLoadHasFired = false;
+var bf = new framework.ioc("/tests/model").onLoad(function(beanFactory){
+        onLoadHasFired = true;
+    });
+var q = bf.containsBean( "foo" );
+assertTrue( onLoadHasFired ); 

--- a/tests/OnLoadTest.cfc
+++ b/tests/OnLoadTest.cfc
@@ -44,13 +44,8 @@ component extends="mxunit.framework.TestCase" {
      function shouldBeAbleToUseFunctionExpressionListener() {
         
         if (listFirst(server.coldfusion.productVersion) >= 10) {
-
-            var onLoadHasFired = false;
-            var bf = new framework.ioc("/tests/model").onLoad(function(beanFactory){
-                    onLoadHasFired = true;
-                });
-            var q = bf.containsBean( "foo" );
-            assertTrue( onLoadHasFired );    
+            //splitting this out so that it doesnt break the tests when running on cf9
+            include "OnLoadTest-cf10.cfm";   
         }
         
     }


### PR DESCRIPTION
cf10 says isObject for function expressions == true, so reworked the if structure in onloadevent. Updated the tests to not fail with a compile error on cf9.

https://github.com/framework-one/fw1/issues/278
