### PR TITLE
Changed "folderList" to "folders" in findProjectFile()

### DIFF
--- a/framework/ioclj.cfc
+++ b/framework/ioclj.cfc
@@ -195,7 +195,7 @@ component extends=framework.ioc {
                 return path;
             }
         }
-        throw "Unable to find project.clj in any of: #folderList#";
+        throw "Unable to find project.clj in any of: #arrayToList( folders )#";
     }
 
 }


### PR DESCRIPTION
It looks like "folderList" is now "folders", which was referenced in the throw(). This results in a variable does not exist error if the throw is triggered.

Changed "folderList" to "folders" and converted it from an array to a list so it can be displayed in the thrown message string.