### PR TITLE
Added a content reset before rendering data with content type.

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1925,6 +1925,9 @@ component {
                    detail = 'renderData() called with unknown type: ' & type );
             break;
         }
+        // Reset content
+        getPageContext().getCFOutput().clearAll();
+        // Set status code
         getPageContext().getResponse().setStatus( statusCode );
         // Set the content type header portably:
         getPageContext().getResponse().setContentType( contentType );


### PR DESCRIPTION
This makes sure that the user only gets what they are requesting at time of render.

Hey Sean, playing a little more with this today and even though this might not be critical, I thought it might help someone who may get stomped by this. The scenario was basically this. I had a dump (or any content written) before calling the renderData() function which then became part of the rendered result. Of course this happened only during a simple debug that I was doing which I had forgotten to abort. I guess it could be helpful lets say if someone left a dump or any other content out there in code before the renderData() function is called.