### PR TITLE
Revert "Added a content reset before rendering data with content type."

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1925,9 +1925,6 @@ component {
                    detail = 'renderData() called with unknown type: ' & type );
             break;
         }
-        // Reset content
-        getPageContext().getCFOutput().clearAll();
-        // Set status code
         getPageContext().getResponse().setStatus( statusCode );
         // Set the content type header portably:
         getPageContext().getResponse().setContentType( contentType );


### PR DESCRIPTION
Reverts framework-one/fw1#342

Not portable: does not work on Lucee.