### PR TITLE
For #325 add placeholder specific regex syntax for routes

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1779,11 +1779,22 @@ component {
             if ( !len( routeRegEx.target ) || right( routeRegEx.target, 1) != '/' ) routeRegEx.target &= '/';
             // walk for self defined (regex) and :var -  replace :var with ([^/]*) in route and back reference in target:
             var n = 1;
-            var placeholders = rematch( '(:[-_a-zA-Z0-9]+)|(\([^\)]+)', routeRegEx.pattern );
+            var placeholders = rematch( '(\{[-_a-zA-Z0-9]+:[^\}]*\})|(:[-_a-zA-Z0-9]+)|(\([^\)]+)', routeRegEx.pattern );
             for ( var placeholder in placeholders ) {
-                if ( left( placeholder, 1 ) == ':') {
+                var placeholderFirstChar = left( placeholder, 1 );
+                if ( placeholderFirstChar == ':') {
                     routeRegEx.pattern = replace( routeRegEx.pattern, placeholder, '([^/]*)' );
                     routeRegEx.target = replace( routeRegEx.target, placeholder, chr(92) & n );
+                }
+                else if ( placeholderFirstChar == '{') {
+                    var findPlaceholderSpecificRegex = refind("\{([^:]*):([^\}]*)\}", placeholder, 1, true);
+                    var placeholderSpecificRegexFound = arrayLen(findPlaceholderSpecificRegex.pos) gte 3;
+                    if( placeholderSpecificRegexFound ){
+                        var placeholderName = mid( placeholder, findPlaceholderSpecificRegex.pos[2], findPlaceholderSpecificRegex.len[2] );
+                        var placeholderSpecificRegex = mid( placeholder, findPlaceholderSpecificRegex.pos[3], findPlaceholderSpecificRegex.len[3] );
+                        routeRegEx.pattern = replace( routeRegEx.pattern, placeholder, "(#placeholderSpecificRegex#)" );
+                        routeRegEx.target = replace( routeRegEx.target, ":" & placeholderName, chr(92) & n );
+                    }
                 }
                 ++n;
             }

--- a/tests/frameworkRouteTest.cfc
+++ b/tests/frameworkRouteTest.cfc
@@ -63,6 +63,10 @@ component extends="tests.InjectableTest" {
         match = variables.fw.processRouteMatch(route, target, "/test/5/something.html/", "GET");
         assertTrue(match.matched);
         assertEquals("default.main/id/5/type/html/", rereplace(match.path, match.pattern, match.target));
+
+        match = variables.fw.processRouteMatch("/product/{id:[0-9]+}-:name.html", "product.detail?id=:id&name=:name", "/product/1-computer.html", "GET");
+        assertTrue(match.matched);
+        assertEquals("product.detail?id=1&name=computer/", rereplace(match.path, match.pattern, match.target));
     }
     
     public void function testRouteMatchMethod()


### PR DESCRIPTION
> I definitely think we wouldn't want to repeat the regex in the target route so {id:[0-9]+} in the route would match :id in the target so if you can add that in

Done