### PR TITLE
Update to beanProxy to prevent reused interceptors over augmented.

### DIFF
--- a/framework/beanProxy.cfc
+++ b/framework/beanProxy.cfc
@@ -375,7 +375,10 @@ component {
 		}
 
 
-		augmentInterceptor(arguments.interceptor);
+		if (!structKeyExists(arguments.interceptor.bean, "interceptorAugmented"))
+		{
+			augmentInterceptor(arguments.interceptor);
+		}
 
 
 		// Maintain the list of intercepted methods. '*' and blank means all.
@@ -433,6 +436,7 @@ component {
 
 		arguments.interceptor.bean._inject = _inject;
 
+		arguments.interceptor.bean._inject("interceptorAugmented", true);
 		arguments.interceptor.bean._inject("interceptedMethods", arguments.interceptor.methods, "private");
 		arguments.interceptor.bean._inject("translateArgs", _translateArgs, "private");
 


### PR DESCRIPTION
Altered the beanProxy to prevent interceptors from having the augment method called on them more than 1 time.