### PR TITLE
Add box.json for ForgeBox / Commandbox

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name" : "Framework One",
-    "slug" : "fw1",
+    "slug" : "fw1-test-box-json",
     "version" : "3.1",
     "author" : "Sean Corfield, Marcin Szczepanski, Ryan Cogswell",
     "location" : "https://github.com/framework-one/fw1/archive/master.zip",
@@ -28,5 +28,5 @@
         { "type" : "Apache 2.0", "URL" : "http://www.apache.org/licenses/LICENSE-2.0" }
     ],
     "Contributors" : [ {"name": "Contributors List", "url": "https://github.com/framework-one/fw1/graphs/contributors"} ],
-    "ignore" : [ "css", "docs", "examples", "introduction", "skeleton", "tests", ".gitignore", ".travis.yml", "code_of_conduct.md", "contributing.md", "readme.md", "build.xml", "run-tests-example.sh" ]
+    "ignore" : [ "index.cfm", "Application.cfc", "css", "docs", "examples", "introduction", "skeleton", "tests", ".gitignore", ".travis.yml", "code_of_conduct.md", "contributing.md", "readme.md", "build.xml", "run-tests-example.sh" ]
 }

--- a/box.json
+++ b/box.json
@@ -5,7 +5,7 @@
     "author" : "Sean Corfield, Marcin Szczepanski, Ryan Cogswell",
     "location" : "https://github.com/framework-one/fw1/archive/master.zip",
     "createPackageDirectory" : true,
-    "packageDirectory" : "",
+    "packageDirectory" : "framework",
     "Homepage" : "http://framework-one.github.io/",
     "Documentation" : "http://framework-one.github.io/documentation/",
     "Repository" : {

--- a/box.json
+++ b/box.json
@@ -1,6 +1,6 @@
 {
     "name" : "Framework One",
-    "slug" : "fw1-test-box-json",
+    "slug" : "fw1",
     "version" : "3.1",
     "author" : "Sean Corfield, Marcin Szczepanski, Ryan Cogswell",
     "location" : "https://github.com/framework-one/fw1/archive/master.zip",

--- a/box.json
+++ b/box.json
@@ -9,7 +9,7 @@
     "Homepage" : "http://framework-one.github.io/",
     "Documentation" : "http://framework-one.github.io/documentation/",
     "Repository" : {
-        "type" : "git", "URL" : "https://github.com/framework-one/fw1"
+        "type" : "git", "URL" : "https://github.com/framework-one/fw1.git"
     },
     "Bugs" : "https://github.com/framework-one/fw1/issues",
     "shortDescription" : "FW/1 - Framework One - is a family of small, lightweight, convention-over-configuration frameworks, primarily for CFML.",

--- a/box.json
+++ b/box.json
@@ -1,0 +1,32 @@
+{
+    "name" : "Framework One",
+    "slug" : "fw1",
+    "version" : "3.1",
+    "author" : "Sean Corfield, Marcin Szczepanski, Ryan Cogswell",
+    "location" : "https://github.com/framework-one/fw1/archive/master.zip",
+    "createPackageDirectory" : "true",
+    "packageDirectory" : "framework",
+    "Homepage" : "http://framework-one.github.io/",
+    "Documentation" : "http://framework-one.github.io/documentation/",
+    "Repository" : {
+        "type" : "git", "URL" : "https://github.com/framework-one/fw1"
+    },
+    "Bugs" : "https://github.com/framework-one/fw1/issues",
+    "shortDescription" : "FW/1 - Framework One - is a family of small, lightweight, convention-over-configuration frameworks, primarily for CFML.",
+    "description" : "FW/1 - Framework One - is a family of small, lightweight, convention-over-configuration frameworks, primarily for CFML. FW/1 itself provides MVC, DI/1 provides dependency injection (a.k.a. inversion of control), and AOP/1 provides aspect-oriented programming features on top of DI/1.",
+    "instructions" : "http://framework-one.github.io/documentation/",
+    "changelog" : "https://github.com/framework-one/fw1/commits/master",
+    "type" : "mvc",
+    "keywords" : [ "fw1", "framework one", "mvc", "conventions" ],
+    "private" : "false",
+    "engines" : [
+        { "type" : "railo", "version" : ">=4.1.x" },
+        { "type" : "lucee", "version" : ">=4.5.x" },
+        { "type" : "adobe", "version" : ">=9.0.2" }
+    ],
+    "License" : [
+        { "type" : "Apache 2.0", "URL" : "http://www.apache.org/licenses/LICENSE-2.0" }
+    ],
+    "Contributors" : [ {"name": "Contributors List", "url": "https://github.com/framework-one/fw1/graphs/contributors"} ],
+    "ignore" : [ "css", "docs", "examples", "introduction", "skeleton", "tests", ".gitignore", ".travis.yml", "code_of_conduct.md", "contributing.md", "readme.md", "build.xml", "run-tests-example.sh" ]
+}

--- a/box.json
+++ b/box.json
@@ -4,8 +4,8 @@
     "version" : "3.1",
     "author" : "Sean Corfield, Marcin Szczepanski, Ryan Cogswell",
     "location" : "https://github.com/framework-one/fw1/archive/master.zip",
-    "createPackageDirectory" : "true",
-    "packageDirectory" : "framework",
+    "createPackageDirectory" : true,
+    "packageDirectory" : "",
     "Homepage" : "http://framework-one.github.io/",
     "Documentation" : "http://framework-one.github.io/documentation/",
     "Repository" : {


### PR DESCRIPTION
So here's a box.json for ForgeBox / CommandBox. It's set up to pull from the `master` repository and install _only_ the `/framework` folder. There are other fields that can be added to box.json (see [here](http://ortus.gitbooks.io/commandbox-documentation/content/packages/boxjson/boxjson.html)), if needed, but the current setup is efficient enough to install the FW/1 files.

So far it has been tested in CommandBox (2.0), pulling from a forked repository, by running `box install https://github.com/cfchef/fw1/archive/master.zip`. Now that I've moved it to `develop`, it will pull from that repo instead.

By updating the [FW/1 package on ForgeBox](http://www.coldbox.org/forgebox/view/fw1) to include the box.json data, you should then be able to do `box install fw1` and get the same results.

Note: In Brad's [comment on issue #260](https://github.com/framework-one/fw1/issues/260#issuecomment-122629329), he state's that `createPackageDirectory` should be set to `false` when pulling from a repo; however, I had to set it to `true` in order for things to install properly.

If all seems well, the next thing I'll look into is commands to do things like `fw1 create controller x` and recipes to possibly handle general scaffolding of scenarios like single vs subsystem apps.