### PR TITLE
Attempt to indicate which file is broken

### DIFF
--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -409,24 +409,28 @@ component {
             var singleDir = singular( dir );
             var beanName = listLast( relPath, '/' );
             var dottedPath = dotted & replace( relPath, '/', '.', 'all' );
-            var metadata = {
-                name = beanName, qualifier = singleDir, isSingleton = !beanIsTransient( singleDir, dir, beanName ),
-                path = cfcPath, cfc = dottedPath, metadata = cleanMetadata( dottedPath )
-            };
-            if ( structKeyExists( metadata.metadata, "type" ) && metadata.metadata.type == "interface" ) {
-                continue;
-            }
-            if ( structKeyExists( variables.beanInfo, beanName ) ) {
-                if ( variables.config.omitDirectoryAliases ) {
-                    throw '#beanName# is not unique (and omitDirectoryAliases is true)';
+            try {
+                var metadata = {
+                    name = beanName, qualifier = singleDir, isSingleton = !beanIsTransient( singleDir, dir, beanName ),
+                    path = cfcPath, cfc = dottedPath, metadata = cleanMetadata( dottedPath )
+                };
+                if ( structKeyExists( metadata.metadata, "type" ) && metadata.metadata.type == "interface" ) {
+                    continue;
                 }
-                structDelete( variables.beanInfo, beanName );
-                variables.beanInfo[ beanName & singleDir ] = metadata;
-            } else {
-                variables.beanInfo[ beanName ] = metadata;
-                if ( !variables.config.omitDirectoryAliases ) {
+                if ( structKeyExists( variables.beanInfo, beanName ) ) {
+                    if ( variables.config.omitDirectoryAliases ) {
+                        throw '#beanName# is not unique (and omitDirectoryAliases is true)';
+                    }
+                    structDelete( variables.beanInfo, beanName );
                     variables.beanInfo[ beanName & singleDir ] = metadata;
+                } else {
+                    variables.beanInfo[ beanName ] = metadata;
+                    if ( !variables.config.omitDirectoryAliases ) {
+                        variables.beanInfo[ beanName & singleDir ] = metadata;
+                    }
                 }
+            } catch( any e ) {
+                throw 'bean discovery error: #beanName# (#dottedPath#); original message: #e.message#';
             }
         }
     }


### PR DESCRIPTION
This is inspired by a bug in our code that manifested as:

> Element TYPE is undefined in BASEMETADATA.
>
> Stack trace:
> framework\ioc.cfc:264
> framework\ioc.cfc:414
> framework\ioc.cfc:378
> ...

Obviously there's a missing "type" attribute, but the problem is that we're not told which component is at fault. This PR aims to try and fix that.