### PR TITLE
Changes example buildURLs to use '?' instead of '&'

### DIFF
--- a/examples/subsystems/4hellocontroller/views/main/default.cfm
+++ b/examples/subsystems/4hellocontroller/views/main/default.cfm
@@ -1,4 +1,4 @@
 <cfoutput>
   <p>Hello #rc.name#!</p>
-  <p><a href="#buildURL('main.other&name=#rc.name#')#">Go away</a>!</p>
+  <p><a href="#buildURL('main.other?name=#rc.name#')#">Go away</a>!</p>
 </cfoutput>

--- a/examples/subsystems/5helloservice/views/main/default.cfm
+++ b/examples/subsystems/5helloservice/views/main/default.cfm
@@ -1,4 +1,4 @@
 <cfoutput>
   <p>Hello #rc.name#!</p>
-  <p><a href="#buildURL('main.other&name=#rc.name#')#">Go away</a>!</p>
+  <p><a href="#buildURL('main.other?name=#rc.name#')#">Go away</a>!</p>
 </cfoutput>


### PR DESCRIPTION
If you have generateSES=true and SESOmitIndex=true, ampersand results
in viewNotFound ‘/views/main/other&name=anonymous.cfm’