### PR TITLE
hasParent Method

### DIFF
--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -92,11 +92,6 @@ component {
   		return structKeyExists(variables, 'parent');
   	}
 
-  	// return all beanNames of this factory as an array
-  	public array function getBeanNames() {
-  		return listToArray( structKeyList( variables.beanInfo ) );
-  	}
-
     // programmatically register new beans with the factory (add an actual CFC)
     public any function declareBean( string beanName, string dottedPath, boolean isSingleton = true, struct overrides = { } ) {
         discoverBeans();

--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -87,6 +87,15 @@ component {
                 ( structKeyExists( variables, 'parent' ) && variables.parent.containsBean( beanName ) );
     }
 
+    // return true if this factory has a parent.
+  	public boolean function hasParent() {
+  		return structKeyExists(variables, 'parent');
+  	}
+
+  	// return all beanNames of this factory as an array
+  	public array function getBeanNames() {
+  		return listToArray( structKeyList( variables.beanInfo ) );
+  	}
 
     // programmatically register new beans with the factory (add an actual CFC)
     public any function declareBean( string beanName, string dottedPath, boolean isSingleton = true, struct overrides = { } ) {


### PR DESCRIPTION
This pull request only has the hasParent method. My earlier pull request also had the getBeanNames method but as you rightfully mentioned that getBeanInfo already supplies information on all beans if you don't provide it with a beanName, I removed that method. I never went into the code of getBeanInfo as the name suggested it would deal with a single bean. Didn't know that if no bean name is provided the method returns info on all beans.