### PR TITLE
Issue420

### DIFF
--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -891,6 +891,9 @@ component {
                     }
                 }
                 accumulator.bean = bean;
+                if ( !isSingleton( beanName ) && structKeyExists( accumulator.injection, beanName ) ) {
+                    accumulator.injection[ beanName ].bean = accumulator.bean;
+                }
             } else if ( isConstant( beanName ) ) {
                 accumulator.bean = info.value;
                 accumulator.injection[ beanName ] = { bean = info.value, setters = { } };

--- a/tests/TransientInjectionTest.cfc
+++ b/tests/TransientInjectionTest.cfc
@@ -1,0 +1,22 @@
+component extends="mxunit.framework.TestCase" {
+
+    function shouldReturnWiredTransient() {
+        // issue #420
+        var bf = new framework.ioc( "" );
+        bf.declareBean("transient", "tests.issue420.transient", false);
+        bf.declareBean("singleton", "tests.issue420.singleton", true);
+
+        assertTrue( bf.containsBean( "transient" ) );
+        assertFalse( bf.isSingleton( "transient" ) );
+
+        var singleton = bf.getBean( "transient" ).getSingleton();
+        assertTrue( isValid( "component", singleton ), "should return the singleton instance on the 1st call" );
+        assertTrue( isValid( "component", singleton.getBeanFactory() ), "should return ioc instance on the 1st call" );
+
+        // call again to check subsequent calls return wired transient
+        singleton = bf.getBean( "transient" ).getSingleton();
+        assertTrue( isValid( "component", singleton ), "should return the singleton instance on the 2nd call" );
+        assertTrue( isValid( "component", singleton.getBeanFactory() ), "should return ioc instance on the 2nd call" );
+    }
+
+}

--- a/tests/issue420/singleton.cfc
+++ b/tests/issue420/singleton.cfc
@@ -1,0 +1,8 @@
+component accessors="true" {
+
+  property name="beanFactory";
+
+  function init() {
+    return this;
+  }
+}

--- a/tests/issue420/transient.cfc
+++ b/tests/issue420/transient.cfc
@@ -1,0 +1,8 @@
+component accessors="true" {
+
+  property name="singleton";
+
+  function init() {
+    return this;
+  }
+}


### PR DESCRIPTION
Added a test to replicate the issue where subsequent calls to getBean for a transient returns the transient, but dependencies are not being injected.

Implemented the fix suggested by @georgebridgeman on the ticket:
https://github.com/framework-one/fw1/issues/420
