### PR TITLE
Fix for issue #452

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -111,6 +111,11 @@ component {
             action = replace( action, '.', getSubsystemSectionAndItem() );
         }
         var pathData = resolveBaseURL( action, path );
+        // remove trailing "/" (& leading "/" if passed into action)
+        if ( len( pathData.path ) && right( pathData.path, 1 ) == '/' ) {
+            if ( len( action ) >= 1 && left( action, 1 ) == '/' ) action = replace( action, '/', '', 'one' );
+            pathData.path = left( pathData.path, len( pathData.path ) - 1 );
+        }
         path = pathData.path;
         var omitIndex = pathData.omitIndex;
         queryString = normalizeQueryString( queryString );

--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -111,10 +111,10 @@ component {
             action = replace( action, '.', getSubsystemSectionAndItem() );
         }
         var pathData = resolveBaseURL( action, path );
-        // remove trailing "/" (& leading "/" if passed into action)
+        // remove trailing "/"
         if ( len( pathData.path ) && right( pathData.path, 1 ) == '/' ) {
-            if ( len( action ) >= 1 && left( action, 1 ) == '/' ) action = replace( action, '/', '', 'one' );
-            pathData.path = left( pathData.path, len( pathData.path ) - 1 );
+            if ( len( action ) == 1 && left( action, 1 ) == '/' ) action = '';
+            else pathData.path = left( pathData.path, len( pathData.path ) - 1 );
         }
         path = pathData.path;
         var omitIndex = pathData.omitIndex;

--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -111,11 +111,6 @@ component {
             action = replace( action, '.', getSubsystemSectionAndItem() );
         }
         var pathData = resolveBaseURL( action, path );
-        // remove trailing "/"
-        if ( len( pathData.path ) && right( pathData.path, 1 ) == '/' ) {
-            if ( len( action ) == 1 && left( action, 1 ) == '/' ) action = '';
-            else pathData.path = left( pathData.path, len( pathData.path ) - 1 );
-        }
         path = pathData.path;
         var omitIndex = pathData.omitIndex;
         queryString = normalizeQueryString( queryString );
@@ -2471,6 +2466,10 @@ component {
         }
         if ( !structKeyExists(variables.framework, 'baseURL') ) {
             variables.framework.baseURL = 'useCgiScriptName';
+        }
+        // remove trailing "/" from baseURL
+        if ( len( variables.framework.baseURL ) > 1 && right( variables.framework.baseURL, 1 ) == '/' ) {
+            variables.framework.baseURL = left( variables.framework.baseURL, len( variables.framework.baseURL ) - 1 );
         }
         if ( !structKeyExists(variables.framework, 'generateSES') ) {
             variables.framework.generateSES = false;

--- a/tests/onSessionStartBuildURLTest.cfc
+++ b/tests/onSessionStartBuildURLTest.cfc
@@ -38,8 +38,8 @@ component extends="tests.InjectableTest" {
     public void function testURLandURIempty() {
         variables.fwvars.framework.baseURL = "/tests/ci/";
         variables.fw.onRequestStart("/index.cfm");
-        assertEquals( "/tests/ci/", variables.fw.getBaseURL() );
-        assertEquals( "/tests/ci/", variables.fw.buildURL( action = 'main.default' ) );
+        assertEquals( "/tests/ci", variables.fw.getBaseURL() );
+        assertEquals( "/tests/ci", variables.fw.buildURL( action = 'main.default' ) );
         assertEquals( "/tests/ci/main/default", variables.fw.buildCustomURL( uri = '/main/default' ) );
     }
 


### PR DESCRIPTION
Removes the trailing "/" that may be included in `framework.baseURL` - Example: `http://" & cgi.HTTP_HOST & "/myapp/`.

Tested URLs to build:
```
buildURL( 'product.list' )
buildURL( action = 'product.detail', queryString = 'id=42?img=large##overview' )
buildURL( 'product.detail?id=42?img=large##overview' )
buildURL( '.list' )
```