### PR TITLE
Wiring under load

### DIFF
--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -874,29 +874,29 @@ component {
                         }
                     }
                 }
-              }
 /* ***************************************************** */
-              if ( !structKeyExists( accumulator.injection, beanName ) ) {
-                  if ( !structKeyExists( variables.settersInfo, beanName ) ) {
-                      variables.settersInfo[ beanName ] = findSetters( bean, info.metadata );
-                  }
-                  var setterMeta = {
-                      setters = variables.settersInfo[ beanName ].setters,
-                      bean = bean,
-                      overrides = overrides
-                  };
-                  accumulator.injection[ beanName ] = setterMeta;
-                  for ( var property in setterMeta.setters ) {
-                      accumulator.dependencies[ beanName ][ property ] = true;
-                      if ( structKeyExists( overrides, property ) ) {
-                          // skip resolution because we'll inject override
-                      } else {
-                          resolveBeanCreate( property, accumulator );
-                      }
-                  }
-              }
-              if ( !isSingleton( beanName ) && structKeyExists( accumulator.injection, beanName ) ) {
-                  accumulator.injection[ beanName ].bean = bean;
+                if ( !structKeyExists( accumulator.injection, beanName ) ) {
+                    if ( !structKeyExists( variables.settersInfo, beanName ) ) {
+                        variables.settersInfo[ beanName ] = findSetters( bean, info.metadata );
+                    }
+                    var setterMeta = {
+                        setters = variables.settersInfo[ beanName ].setters,
+                        bean = bean,
+                        overrides = overrides
+                    };
+                    accumulator.injection[ beanName ] = setterMeta;
+                    for ( var property in setterMeta.setters ) {
+                        accumulator.dependencies[ beanName ][ property ] = true;
+                        if ( structKeyExists( overrides, property ) ) {
+                            // skip resolution because we'll inject override
+                        } else {
+                            resolveBeanCreate( property, accumulator );
+                        }
+                    }
+                }
+                if ( !isSingleton( beanName ) && structKeyExists( accumulator.injection, beanName ) ) {
+                    accumulator.injection[ beanName ].bean = bean;
+                }
               }
             } else if ( isConstant( beanName ) ) {
                 bean = info.value;

--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -811,7 +811,8 @@ component {
             var info = variables.beanInfo[ beanName ];
             if ( !structKeyExists( accumulator.dependencies, beanName ) ) accumulator.dependencies[ beanName ] = { };
             if ( structKeyExists( info, 'cfc' ) ) {
-/*******************************************************/
+/* ***************************************************** */
+              lock name="#application.applicationName#_ioc1_#beanName#" type="exclusive" timeout="10" {
                 var metaBean = cachable( beanName );
                 var overrides = { };
                 // be careful not to modify overrides metadata:
@@ -873,29 +874,30 @@ component {
                         }
                     }
                 }
-/*******************************************************/
-                if ( !structKeyExists( accumulator.injection, beanName ) ) {
-                    if ( !structKeyExists( variables.settersInfo, beanName ) ) {
-                        variables.settersInfo[ beanName ] = findSetters( bean, info.metadata );
-                    }
-                    var setterMeta = {
-                        setters = variables.settersInfo[ beanName ].setters,
-                        bean = bean,
-                        overrides = overrides
-                    };
-                    accumulator.injection[ beanName ] = setterMeta;
-                    for ( var property in setterMeta.setters ) {
-                        accumulator.dependencies[ beanName ][ property ] = true;
-                        if ( structKeyExists( overrides, property ) ) {
-                            // skip resolution because we'll inject override
-                        } else {
-                            resolveBeanCreate( property, accumulator );
-                        }
-                    }
-                }
-                if ( !isSingleton( beanName ) && structKeyExists( accumulator.injection, beanName ) ) {
-                    accumulator.injection[ beanName ].bean = bean;
-                }
+              }
+/* ***************************************************** */
+              if ( !structKeyExists( accumulator.injection, beanName ) ) {
+                  if ( !structKeyExists( variables.settersInfo, beanName ) ) {
+                      variables.settersInfo[ beanName ] = findSetters( bean, info.metadata );
+                  }
+                  var setterMeta = {
+                      setters = variables.settersInfo[ beanName ].setters,
+                      bean = bean,
+                      overrides = overrides
+                  };
+                  accumulator.injection[ beanName ] = setterMeta;
+                  for ( var property in setterMeta.setters ) {
+                      accumulator.dependencies[ beanName ][ property ] = true;
+                      if ( structKeyExists( overrides, property ) ) {
+                          // skip resolution because we'll inject override
+                      } else {
+                          resolveBeanCreate( property, accumulator );
+                      }
+                  }
+              }
+              if ( !isSingleton( beanName ) && structKeyExists( accumulator.injection, beanName ) ) {
+                  accumulator.injection[ beanName ].bean = bean;
+              }
             } else if ( isConstant( beanName ) ) {
                 bean = info.value;
                 accumulator.injection[ beanName ] = { bean = info.value, setters = { } };

--- a/tests/iocLoad/Application.cfc
+++ b/tests/iocLoad/Application.cfc
@@ -1,0 +1,30 @@
+component {
+
+  this.mappings[ '/framework' ] = expandPath( '../../framework' );
+  this.mappings[ '/beans' ] = expandPath( './beans' );
+
+  function onRequestStart() {
+    if (structKeyExists(url, "reinit")) {
+      structDelete(application, "beanFactory");
+    }
+    if (!structKeyExists(application, "beanFactory")) {
+      lock scope="application" timeout="5" {
+        var bf = new framework.ioc(folders=[]);
+        bf.declare("Greeting").asValue("Hello");
+        // this singleton has a constructor dependancy on Greeting
+        bf.declare("Singleton").instanceOf("beans.Singleton").asSingleton();
+        // this transient has a setter dependancy on Singleton
+        bf.declare("Transient").instanceOf("beans.Transient").asTransient();
+        application.beanFactory = bf;
+      }
+    }
+  }
+
+  function onError(Exception, eventName) {
+    if (structKeyExists(Exception, "message")) {
+      writeOutput(Exception.message);
+    }
+    writeDump(var=Exception, format="text");
+  }
+
+}

--- a/tests/iocLoad/beans/Singleton.cfc
+++ b/tests/iocLoad/beans/Singleton.cfc
@@ -1,0 +1,9 @@
+component {
+  function init(greeting) {
+    variables.greeting = greeting;
+    return this;
+  }
+  function greet(required string whom) {
+    return variables.greeting & " " & whom;
+  }
+}

--- a/tests/iocLoad/beans/Transient.cfc
+++ b/tests/iocLoad/beans/Transient.cfc
@@ -1,0 +1,13 @@
+component accessors="true" {
+
+  property name="Singleton" type="any";
+
+  function init() {
+    variables.greeting = "Hello";
+    return this;
+  }
+  
+  function sayHi(required string whom) {
+    return variables.singleton.greet(whom);
+  }
+}

--- a/tests/iocLoad/index.cfm
+++ b/tests/iocLoad/index.cfm
@@ -1,0 +1,1 @@
+<cfoutput>#application.beanFactory.getBean("Transient").sayHi("World")#</cfoutput>

--- a/tests/iocLoad/jmeter/TestPlan.jmx
+++ b/tests/iocLoad/jmeter/TestPlan.jmx
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="2.6" jmeter="2.11.20151206">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1000</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">5</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1479760673000</longProp>
+        <longProp name="ThreadGroup.end_time">1479760673000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">localhost</stringProp>
+          <stringProp name="HTTPSampler.port">8765</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path"></stringProp>
+          <stringProp name="HTTPSampler.concurrentPool">4</stringProp>
+        </ConfigTestElement>
+        <hashTree/>
+        <OnceOnlyController guiclass="OnceOnlyControllerGui" testclass="OnceOnlyController" testname="Once Only Controller" enabled="true"/>
+        <hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Reload DI/1" enabled="true">
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain"></stringProp>
+            <stringProp name="HTTPSampler.port"></stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="HTTPSampler.protocol"></stringProp>
+            <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+            <stringProp name="HTTPSampler.path">/tests/iocLoad/index.cfm?reinit=true</stringProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <boolProp name="HTTPSampler.monitor">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Should return Hello World" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/tests/iocLoad/index.cfm</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="-424128902">^Hello World\W+$</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">1</intProp>
+          </ResponseAssertion>
+          <hashTree/>
+          <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+            <boolProp name="ResultCollector.error_logging">false</boolProp>
+            <objProp>
+              <name>saveConfig</name>
+              <value class="SampleSaveConfiguration">
+                <time>true</time>
+                <latency>true</latency>
+                <timestamp>true</timestamp>
+                <success>true</success>
+                <label>true</label>
+                <code>true</code>
+                <message>true</message>
+                <threadName>true</threadName>
+                <dataType>true</dataType>
+                <encoding>false</encoding>
+                <assertions>true</assertions>
+                <subresults>true</subresults>
+                <responseData>false</responseData>
+                <samplerData>false</samplerData>
+                <xml>false</xml>
+                <fieldNames>false</fieldNames>
+                <responseHeaders>false</responseHeaders>
+                <requestHeaders>false</requestHeaders>
+                <responseDataOnError>false</responseDataOnError>
+                <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+                <assertionsResultsToSave>0</assertionsResultsToSave>
+                <bytes>true</bytes>
+              </value>
+            </objProp>
+            <stringProp name="filename"></stringProp>
+          </ResultCollector>
+          <hashTree/>
+          <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+            <boolProp name="ResultCollector.error_logging">true</boolProp>
+            <objProp>
+              <name>saveConfig</name>
+              <value class="SampleSaveConfiguration">
+                <time>true</time>
+                <latency>true</latency>
+                <timestamp>true</timestamp>
+                <success>true</success>
+                <label>true</label>
+                <code>true</code>
+                <message>true</message>
+                <threadName>true</threadName>
+                <dataType>true</dataType>
+                <encoding>false</encoding>
+                <assertions>true</assertions>
+                <subresults>true</subresults>
+                <responseData>false</responseData>
+                <samplerData>false</samplerData>
+                <xml>false</xml>
+                <fieldNames>false</fieldNames>
+                <responseHeaders>false</responseHeaders>
+                <requestHeaders>false</requestHeaders>
+                <responseDataOnError>false</responseDataOnError>
+                <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+                <assertionsResultsToSave>0</assertionsResultsToSave>
+                <bytes>true</bytes>
+              </value>
+            </objProp>
+            <stringProp name="filename"></stringProp>
+          </ResultCollector>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/tests/iocLoad/readme.md
+++ b/tests/iocLoad/readme.md
@@ -1,0 +1,9 @@
+This is a test for a issue which has been seen under heavy load where a
+transient which has a dependancy on a singleton, doesn't always get wired up.
+
+To run this test you will need to use jMeter (and optional commandbox).
+
+The jMeter test expects the server to accessible at localhost:8765 but you change
+port and hostname in the test. The expected response is 'Hello World'
+
+Then run `tests/iocLoad/jmeter/TestPlan.jmx` in jMeter.


### PR DESCRIPTION
jMeter load Test for a issue which has been seen under heavy load where a transient which has a dependency on a singleton, doesn't always get wired up.

At first I added the lock where the comments were in the code (changing the syntax of the comments slightly so Lucee doesn't think it's metadata!) but still get occasional errors around 0.1% failure. Extended the lock which seems to do the trick but would be interesting to test on faster hardware as my laptop is quite old.

To run this test you will need to use jMeter (and optional commandbox).

The jMeter test expects the server to accessible at localhost:8765 but you change
port and hostname in the test. The expected response is 'Hello World'

DI/1 is reloaded in the the test applications application scope on each test run.

Hope this is helpful.