### PR TITLE
Refactor session scope usage into a series of overridable methods

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1229,15 +1229,15 @@ component {
     }
 
     public void function sessionDefault( string keyname, string defaultValue ) {
-        param name="session['#arguments.keyname#']" default="#arguments.defaultValue#";
+        param name="session['#keyname#']" default="#defaultValue#";
     }
 
     public void function sessionDelete( string keyname ) {
-        structDelete( session, arguments.keyname );
+        structDelete( session, keyname );
     }
 
     public boolean function sessionHas( string keyname ) {
-        return isDefined( 'session.#arguments.keyname#' ) && structKeyExists( session, arguments.keyname );
+        return isDefined( 'session.#keyname#' ) && structKeyExists( session, keyname );
     }
 
     public void function sessionLock( required function callback ) {
@@ -1247,11 +1247,11 @@ component {
     }
 
     public any function sessionRead( string keyname ) {
-        return session[ arguments.keyname ];
+        return session[ keyname ];
     }
 
     public void function sessionWrite( string keyname, any keyvalue ) {
-        session[ arguments.keyname ] = arguments.keyvalue;
+        session[ keyname ] = keyvalue;
     }
 
     /*


### PR DESCRIPTION
Per discussions in slack, this seemed like a welcome contribution.

This is my first attempt at it, but I'm quite open to feedback and suggestions for improvement. In my case we'll be overriding these methods to work with session data going into Redis instead of ACF's session scope.

So far I have made the changes you see here and tested that everything still seems to be in working order in my (somewhat large) app. Once I was happy with these changes I overrode these new extension points and swapped in Redis functionality. I'm using [sidecar](https://github.com/MotorsportReg/sidecar) to manage them, but my examples below should be reasonably readable pseudocode even not knowing how I'm hooking everything up to Redis.

Here's the code I've added to my Application.cfc to override the new extension points:

```js
	public void function sessionDefault( string keyname, string defaultValue ) {
		var tmp = application.sessionAdapter.get( arguments.keyName, arguments.defaultValue );
		application.sessionAdapter.set( arguments.keyName, tmp );
	}

	public void function sessionDelete( string keyname ) {
		application.sessionAdapter.clear( arguments.keyname );
	}

	public boolean function sessionHas( string keyname ) {
		return application.sessionAdapter.has( arguments.keyname );
	}

	public void function sessionLock( required function callback ) {
		lock name="sessionLockAppCFC" type="exclusive" timeout="30" {
			callback();
		}
	}

	public any function sessionRead( string keyname ) {
		return application.sessionAdapter.get( arguments.keyname );
	}

	public void function sessionWrite( string keyname, any keyvalue ) {
		application.sessionAdapter.set( arguments.keyname, arguments.keyvalue );
	}
```

I would love to add tests but to be honest I'm drawing a blank on how to test these changes. Advice is welcome.