### PR TITLE
Don't decode POST requests when decodeRequestBody enabled

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -2813,15 +2813,17 @@ component {
                         }
                         break;
                     case "application/x-www-form-urlencoded":
-                        try {
-                            var paramPairs = listToArray( body, "&" );
-                            for ( var pair in paramPairs ) {
-                                var parts = listToArray( pair, "=", true ); // handle blank values
-                                request.context[ parts[ 1 ] ] = urlDecode( parts[ 2 ] );
+                        if ( CGI.REQUEST_METHOD != "POST" ) {
+                            try {
+                                var paramPairs = listToArray( body, "&" );
+                                for ( var pair in paramPairs ) {
+                                    var parts = listToArray( pair, "=", true ); // handle blank values
+                                    request.context[ parts[ 1 ] ] = urlDecode( parts[ 2 ] );
+                                }
+                            } catch ( any e ) {
+                                throw( type = "FW1.JSONPOST",
+                                    message = "Content-Type implies form encoded but could not deserialize body: " & e.message );
                             }
-                        } catch ( any e ) {
-                            throw( type = "FW1.JSONPOST",
-                                   message = "Content-Type implies form encoded but could not deserialize body: " & e.message );
                         }
                         break;
                     default:


### PR DESCRIPTION
Fixes issue reported in Slack channel by turtmcfly running Lucee 5.0 and FW4.0. This is a nasty solution but catches the issue reported.

POST requests are already decode via form scope, so do not decode when `decodeRequestBody` is enabled.

I don't like the if statement inside a switch statement, so think there is a cleaner version of this.
