### PR TITLE
For ACF append values if key exists when decoding

### DIFF
--- a/examples/rest/Application.cfc
+++ b/examples/rest/Application.cfc
@@ -1,0 +1,34 @@
+component {
+    this.name = 'fw1-examples-rest';
+    this.mappings[ '/framework' ] = expandPath( '../framework' );
+    
+    function _get_framework_one() {
+        if ( !structKeyExists( request, '_framework_one' ) ) {
+            request._framework_one = new framework.one( {
+		        decodeRequestBody = true,
+                reloadApplicationOnEveryRequest = true
+            } );
+        }
+        return request._framework_one;
+    }
+
+    // delegation of lifecycle methods to FW/1:
+    function onApplicationStart() {
+        return _get_framework_one().onApplicationStart();
+    }
+    function onError( exception, event ) {
+        return _get_framework_one().onError( exception, event );
+    }
+    function onRequest( targetPath ) {
+        return _get_framework_one().onRequest( targetPath );
+    }
+    function onRequestEnd() {
+        return _get_framework_one().onRequestEnd();
+    }
+    function onRequestStart( targetPath ) {
+        return _get_framework_one().onRequestStart( targetPath );
+    }
+    function onSessionStart() {
+        return _get_framework_one().onSessionStart();
+    }
+}

--- a/examples/rest/controllers/main.cfc
+++ b/examples/rest/controllers/main.cfc
@@ -1,0 +1,35 @@
+component {
+
+    function init( any fw ) {
+        variables.fw = fw;
+        return this;
+    }
+
+    function patch( struct rc, struct headers ) {
+        var response = {
+            "method": "PATCH",
+            "multi": rc.multi,
+            "single": rc.single
+        };
+        variables.fw.renderData().type( 'json' ).data( response );
+    }
+
+    function post( struct rc, struct headers ) {
+        var response = {
+            "method": "POST",
+            "multi": rc.multi,
+            "single": rc.single
+        };
+        variables.fw.renderData().type( 'json' ).data( response );
+    }
+
+    function put( struct rc, struct headers ) {
+        var response = {
+            "method": "PUT",
+            "multi": rc.multi,
+            "single": rc.single
+        };
+        variables.fw.renderData().type( 'json' ).data( response );
+    }
+
+}

--- a/examples/rest/index.cfm
+++ b/examples/rest/index.cfm
@@ -1,0 +1,1 @@
+<!--- intentionally blank --->

--- a/examples/rest/views/main/default.cfm
+++ b/examples/rest/views/main/default.cfm
@@ -1,0 +1,1 @@
+This rest example is used by the tests to assert that data is decoded as expected

--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -2853,7 +2853,13 @@ component {
                             var paramPairs = listToArray( body, "&" );
                             for ( var pair in paramPairs ) {
                                 var parts = listToArray( pair, "=", true ); // handle blank values
-                                request.context[ parts[ 1 ] ] = urlDecode( parts[ 2 ] );
+                                var keyName = parts[ 1 ];
+                                var keyValue = urlDecode( parts[ 2 ] );
+                                if ( !structKeyExists( request.context, keyName ) ) {
+                                    request.context[ keyName ] = keyValue;
+                                } else {
+                                    request.context[ keyName ] = listAppend( request.context[ keyName ], keyValue );
+                                }
                             }
                         } catch ( any e ) {
                             throw( type = "FW1.JSONPOST",

--- a/tests/rest/DecodeTest.cfc
+++ b/tests/rest/DecodeTest.cfc
@@ -1,0 +1,69 @@
+component extends="mxunit.framework.TestCase" {
+
+    function testPostFormEncodedRequestDecodesMultiField() {
+        var actual = doFormEncodedHTTPRequest( "POST" );
+        assertEquals( "POST", actual.method );
+        assertEquals( "a,b,c", actual.single );
+        assertEquals( "1,2,3,40,50", actual.multi );
+    }
+
+    function testPatchFormEncodedRequestDecodesMultiField() {
+        var actual = doFormEncodedHTTPRequest( "PATCH" );
+        assertEquals( "PATCH", actual.method );
+        assertEquals( "a,b,c", actual.single );
+        assertEquals( "1,2,3,40,50", actual.multi );
+    }
+
+    function testPutFormEncodedRequestDecodesMultiField() {
+        var actual = doFormEncodedHTTPRequest( "PUT" );
+        assertEquals( "PUT", actual.method );
+        assertEquals( "a,b,c", actual.single );
+        assertEquals( "1,2,3,40,50", actual.multi );
+    }
+    
+    function testPostJSONEncodedRequestDecodesMultiField() {
+        var actual = doJSONEncodedHTTPRequest( "POST" );
+        assertEquals( "POST", actual.method );
+        assertEquals( "a,b,c", actual.single );
+        assertEquals( "1,2,3,40,50", actual.multi );
+    }
+
+    function testPatchJSONRequestDecodesMultiField() {
+        var actual = doJSONEncodedHTTPRequest( "PATCH" );
+        assertEquals( "PATCH", actual.method );
+        assertEquals( "a,b,c", actual.single );
+        assertEquals( "1,2,3,40,50", actual.multi );
+    }
+
+    function testPutJSONRequestDecodesMultiField() {
+        var actual = doJSONEncodedHTTPRequest( "PUT" );
+        assertEquals( "PUT", actual.method );
+        assertEquals( "a,b,c", actual.single );
+        assertEquals( "1,2,3,40,50", actual.multi );
+    }
+
+
+
+    private function doFormEncodedHTTPRequest( verb ) {
+        return doHTTPRequest( verb, "application/x-www-form-urlencoded", "multi=1%2C2%2C3&multi=40&multi=50&single=a%2Cb%2Cc" );
+    }
+
+    private function doJSONEncodedHTTPRequest( verb ) {
+        return doHTTPRequest( verb, "application/json", '{"multi": "1,2,3,40,50","single": "a,b,c"}' );
+    }
+    
+    private function doHTTPRequest( verb, contentType, body ) {
+        var httpService = new http();
+        httpService.setmethod( verb );
+        httpService.setCharset( "utf-8" );
+        httpService.setUrl( "http://#CGI.SERVER_NAME#:#CGI.SERVER_PORT#/examples/rest/?action=main.#verb#" ); 
+        httpService.addParam( type = "header", name = "content-type", value = contentType );
+        httpService.addParam( type = "body", value = body );
+        var response = httpService.send().getPrefix().filecontent;
+        if ( isJson( response ) ) {
+            return deserializeJSON( response );
+        }
+        fail( "expected a JSON response for #verb# #contentType#" );
+    }
+
+}

--- a/tests/rest/DecodeTest.cfc
+++ b/tests/rest/DecodeTest.cfc
@@ -7,7 +7,7 @@ component extends="mxunit.framework.TestCase" {
         assertEquals( "1,2,3,40,50", actual.multi );
     }
 
-    function testPatchFormEncodedRequestDecodesMultiField() {
+    function testPatchFormEncodedRequestDecodesMultiField() skip="engineNotSupported" {
         var actual = doFormEncodedHTTPRequest( "PATCH" );
         assertEquals( "PATCH", actual.method );
         assertEquals( "a,b,c", actual.single );
@@ -28,7 +28,7 @@ component extends="mxunit.framework.TestCase" {
         assertEquals( "1,2,3,40,50", actual.multi );
     }
 
-    function testPatchJSONRequestDecodesMultiField() {
+    function testPatchJSONRequestDecodesMultiField() skip="engineNotSupported" {
         var actual = doJSONEncodedHTTPRequest( "PATCH" );
         assertEquals( "PATCH", actual.method );
         assertEquals( "a,b,c", actual.single );
@@ -51,7 +51,7 @@ component extends="mxunit.framework.TestCase" {
     private function doJSONEncodedHTTPRequest( verb ) {
         return doHTTPRequest( verb, "application/json", '{"multi": "1,2,3,40,50","single": "a,b,c"}' );
     }
-    
+
     private function doHTTPRequest( verb, contentType, body ) {
         var httpService = new http();
         httpService.setmethod( verb );
@@ -64,6 +64,10 @@ component extends="mxunit.framework.TestCase" {
             return deserializeJSON( response );
         }
         fail( "expected a JSON response for #verb# #contentType#" );
+    }
+
+    function engineNotSupported() {
+        return server.coldfusion.productname != "Lucee" && ListFirst( server.coldfusion.productversion ) == 10;
     }
 
 }


### PR DESCRIPTION
References:
https://github.com/framework-one/fw1/commit/ebd794bd868e098b6519fdcb328a05ba7e278b7e
https://github.com/framework-one/fw1/pull/477

When testing against `6900ff216449c609e64bbbccf164f5333b41e06e` it all works nicely in Lucee 5 and Lucee 4.5. ACF is not playing nicely though.

This PR addresses that issue.

For PUT / PATCH / DELETE request sent to Adobe ColdFusion the form scope is not populated. Need to do a listAppend for requests which contain multiple key value pairs for example a request body of:

foo=1%2C2%2C3&foo=20&foo=30

Lucee handles populates the form scope for POST / PUT / PATCH / DELETE so doesn't need this code and will override the decoded values with the values from the form scope.

Tested using Postman against:

Lucee 5.2.1 & 4.5.5, Adobe ColdFusion 11 & 2016.0.4
