### PR TITLE
Modify how JAR is created for both engines

### DIFF
--- a/examples/mustache/Application.cfc
+++ b/examples/mustache/Application.cfc
@@ -1,26 +1,16 @@
 component extends=framework.one {
 
     variables.mustacheJAR = expandPath( "compiler-0.9.1.jar" );
-    // adobe coldfusion way:
     this.javaSettings.loadPaths = [ variables.mustacheJAR ];
 
     function setupApplication() {
         var mustacheFactory = "com.github.mustachejava.DefaultMustacheFactory";
         var viewRoot = expandPath( "/" );
-        if ( structKeyExists( server, "lucee" ) ) {
-            // lucee way:
-            application.mustache = createObject(
-                "java", mustacheFactory, variables.mustacheJAR
-            ).init(
-                createObject( "java", "java.io.File" ).init( viewRoot )
-            );
-        } else {
-            application.mustache = createObject(
-                "java", mustacheFactory
-            ).init(
-                createObject( "java", "java.io.File" ).init( viewRoot )
-            );
-        }
+        application.mustache = createObject(
+            "java", mustacheFactory
+        ).init(
+            createObject( "java", "java.io.File" ).init( viewRoot )
+        );
     }
 
     public string function customizeViewOrLayoutPath( struct pathInfo, string type, string fullPath ) {


### PR DESCRIPTION
The way the Mustache JAR is being pulled in for Adobe ColdFusion is supported on Lucee 4.5/5 as well. So I think it makes sense to just use the one way rather then check which engine is running the code.