### PR TITLE
Fix trailing ampersand on query string.

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -2018,7 +2018,7 @@ component {
             var q = '';
             for( var key in queryString ) {
                 if ( isSimpleValue( queryString[key] ) ) {
-                    q &= urlEncodedFormat( key ) & '=' & urlEncodedFormat( queryString[ key ] ) & '&';
+                    q = listAppend(q, urlEncodedFormat( key ) & '=' & urlEncodedFormat( queryString[ key ] ), '&');
                 }
             }
             queryString = q;


### PR DESCRIPTION
I just noticed in my Mura FW/1 plugin that I was getting trailing ampersands when using `buildURL`, so unless this is by design for some reason, I thought it was a simple fix to request.