### PR TITLE
declareBean overrides don't inject without a constructor

### DIFF
--- a/tests/DeclareBeanTest.cfc
+++ b/tests/DeclareBeanTest.cfc
@@ -39,6 +39,19 @@ component extends="mxunit.framework.TestCase" {
         assertSame( item1, item2 );
     }
 
+    function testDeclareBeanNoConstructorSingletonWithOverride() {
+        var bf = new framework.ioc( "" );
+        bf.addBean("known", "i will be auto-wired");
+        bf.declareBean(
+            "foo",
+            "tests.initMethod.myService",
+            true,
+            {result: "i am an override"}
+        );
+        assertEquals( bf.getBean("foo").getKnown(), "i will be auto-wired" );
+        assertEquals( bf.getBean("foo").getResult(), "i am an override" );
+    }
+
     function testDeclareTransientWithOverride() {
         var bf = new framework.ioc( "" )
             .declare( "foo" )


### PR DESCRIPTION
I don't know what the protocol is for submitting a failing test, but here goes.

`declareBean()` with overrides: The overrides don't seem to inject if there's no `init()` method. I would expect it to get set via properties/setters.