### PR TITLE
use encodeForURL instead of urlEncodedFormat

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1095,14 +1095,14 @@ component {
             if ( append == 'all' ) {
                 for ( var key in request.context ) {
                     if ( isSimpleValue( request.context[ key ] ) ) {
-                        baseQueryString = listAppend( baseQueryString, key & '=' & urlEncodedFormat( request.context[ key ] ), '&' );
+                        baseQueryString = listAppend( baseQueryString, key & '=' & encodeForURL( request.context[ key ] ), '&' );
                     }
                 }
             } else {
                 var keys = listToArray( append );
                 for ( var key in keys ) {
                     if ( structKeyExists( request.context, key ) && isSimpleValue( request.context[ key ] ) ) {
-                        baseQueryString = listAppend( baseQueryString, key & '=' & urlEncodedFormat( request.context[ key ] ), '&' );
+                        baseQueryString = listAppend( baseQueryString, key & '=' & encodeForURL( request.context[ key ] ), '&' );
                     }
                 }
 
@@ -2018,7 +2018,7 @@ component {
             var q = '';
             for( var key in queryString ) {
                 if ( isSimpleValue( queryString[key] ) ) {
-                    q = listAppend(q, urlEncodedFormat( key ) & '=' & urlEncodedFormat( queryString[ key ] ), '&');
+                    q = listAppend(q, encodeForURL( key ) & '=' & encodeForURL( queryString[ key ] ), '&');
                 }
             }
             queryString = q;


### PR DESCRIPTION
Was just looking at #491 and noticed that FW/1 is using `urlEncodedFormat`. 

Suggest updating this to use `encodeForURL` instead. This requires ACF10+, but I see that already using `encodeForHTML` which was added in the same ACF release.