### PR TITLE
Only check object beans for post injection init method

### DIFF
--- a/framework/ioc.cfc
+++ b/framework/ioc.cfc
@@ -741,7 +741,7 @@ component {
                     continue;
                 }
                 var injection = partialBean.injection[ name ];
-                if ( checkForPostInjection && !isConstant( name ) && structKeyExists( injection.bean, initMethod ) ) {
+                if ( checkForPostInjection && !isConstant( name ) && isObject(injection.bean) && structKeyExists( injection.bean, initMethod ) ) {
                     postInjectables[ name ] = true;
                 }
                 for ( var property in injection.setters ) {


### PR DESCRIPTION
Beans added to the beanFactory that are strings, structs, arrays etc., should not be checked for having a post injection init method.