### PR TITLE
Allow for AOP/1 to accept an array of folders in the constructor.

### DIFF
--- a/framework/aop.cfc
+++ b/framework/aop.cfc
@@ -27,7 +27,7 @@ component extends="framework.ioc" {
 	// -------------- //
 
 	/** Constructor. */
-	public any function init(string folders, struct config = {})
+	public any function init(any folders, struct config = {})
 	{
 		super.init(argumentCollection = arguments);
 


### PR DESCRIPTION
Changed parameter type from "string" to "any" so an array of folders can be passed into the super.init() call of the aop.cfc constructor.