### PR TITLE
var q and a variables so that it also occurs for cases when there is …

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -114,10 +114,12 @@ component {
         path = pathData.path;
         var omitIndex = pathData.omitIndex;
         queryString = normalizeQueryString( queryString );
+        var q = 0;
+        var a = 0;
         if ( queryString == '' ) {
             // extract query string from action section:
-            var q = find( '?', action );
-            var a = find( '##', action );
+            q = find( '?', action );
+            a = find( '##', action );
             if ( q > 0 ) {
                 if ( q < len( action ) ) {
                     queryString = right( action, len( action ) - q );


### PR DESCRIPTION
…a queryString.  discovered during working through an issue on slack that q and a were not being var scoped when queryString argument was passed in.  