### PR TITLE
Locks are being unnecessarily issued on subsystem setup

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -2989,52 +2989,54 @@ component {
 
     private void function setupSubsystemWrapper( string subsystem ) {
         if ( !len( subsystem ) ) return;
-        lock name="fw1_#application.applicationName#_#variables.framework.applicationKey#_subsysteminit_#subsystem#" type="exclusive" timeout="30" {
-            if ( !isSubsystemInitialized( subsystem ) ) {
-                getFw1App().subsystems[ subsystem ] = now();
-                // Application.cfc does not get a subsystem bean factory!
-                if ( subsystem != variables.magicApplicationSubsystem ) {
-                    var subsystemConfig = getSubsystemConfig( subsystem );
-                    var diEngine = structKeyExists( subsystemConfig, 'diEngine' ) ? subsystemConfig.diEngine : variables.framework.diEngine;
-                    if ( diEngine == "di1" || diEngine == "aop1" ) {
-                        // we can only reliably automate D/I engine setup for DI/1 / AOP/1
-                        var diLocations = structKeyExists( subsystemConfig, 'diLocations' ) ? subsystemConfig.diLocations : variables.framework.diLocations;
-                        var locations = isSimpleValue( diLocations ) ? listToArray( diLocations ) : diLocations;
-                        var subLocations = "";
-                        for ( var loc in locations ) {
-                            var relLoc = trim( loc );
-                            // make a relative location:
-                            if ( len( relLoc ) > 2 && left( relLoc, 2 ) == "./" ) {
-                                relLoc = right( relLoc, len( relLoc ) - 2 );
-                            } else if ( len( relLoc ) > 1 && left( relLoc, 1 ) == "/" ) {
-                                relLoc = right( relLoc, len( relLoc ) - 1 );
-                            }
-                            if ( usingSubsystems() ) {
-                                subLocations = listAppend( subLocations, variables.framework.base & subsystem & "/" & relLoc );
-                            } else {
-                                subLocations = listAppend( subLocations, variables.framework.base & variables.framework.subsystemsFolder & "/" & subsystem & "/" & relLoc );
-                            }
-                        }
-                        if ( len( sublocations ) ) {
-                            var diComponent = structKeyExists( subsystemConfig, 'diComponent' ) ? subsystemConfig : variables.framework.diComponent;
-                            var cfg = { };
-                            if ( structKeyExists( subsystemConfig, 'diConfig' ) ) {
-                                cfg = subsystemConfig.diConfig;
-                            } else {
-                                cfg = structCopy( variables.framework.diConfig );
-                                structDelete( cfg, 'loadListener' );
-                            }
-                            cfg.noClojure = true;
-                            var ioc = new "#diComponent#"( subLocations, cfg );
-                            ioc.setParent( getDefaultBeanFactory() );
-                            setSubsystemBeanFactory( subsystem, ioc );
-                        }
-                    }
-                }
+        if ( !isSubsystemInitialized( subsystem ) ) {       
+			lock name="fw1_#application.applicationName#_#variables.framework.applicationKey#_subsysteminit_#subsystem#" type="exclusive" timeout="30" {
+				if ( !isSubsystemInitialized( subsystem ) ) {
+					getFw1App().subsystems[ subsystem ] = now();
+					// Application.cfc does not get a subsystem bean factory!
+					if ( subsystem != variables.magicApplicationSubsystem ) {
+						var subsystemConfig = getSubsystemConfig( subsystem );
+						var diEngine = structKeyExists( subsystemConfig, 'diEngine' ) ? subsystemConfig.diEngine : variables.framework.diEngine;
+						if ( diEngine == "di1" || diEngine == "aop1" ) {
+							// we can only reliably automate D/I engine setup for DI/1 / AOP/1
+							var diLocations = structKeyExists( subsystemConfig, 'diLocations' ) ? subsystemConfig.diLocations : variables.framework.diLocations;
+							var locations = isSimpleValue( diLocations ) ? listToArray( diLocations ) : diLocations;
+							var subLocations = "";
+							for ( var loc in locations ) {
+								var relLoc = trim( loc );
+								// make a relative location:
+								if ( len( relLoc ) > 2 && left( relLoc, 2 ) == "./" ) {
+									relLoc = right( relLoc, len( relLoc ) - 2 );
+								} else if ( len( relLoc ) > 1 && left( relLoc, 1 ) == "/" ) {
+									relLoc = right( relLoc, len( relLoc ) - 1 );
+								}
+								if ( usingSubsystems() ) {
+									subLocations = listAppend( subLocations, variables.framework.base & subsystem & "/" & relLoc );
+								} else {
+									subLocations = listAppend( subLocations, variables.framework.base & variables.framework.subsystemsFolder & "/" & subsystem & "/" & relLoc );
+								}
+							}
+							if ( len( sublocations ) ) {
+								var diComponent = structKeyExists( subsystemConfig, 'diComponent' ) ? subsystemConfig : variables.framework.diComponent;
+								var cfg = { };
+								if ( structKeyExists( subsystemConfig, 'diConfig' ) ) {
+									cfg = subsystemConfig.diConfig;
+								} else {
+									cfg = structCopy( variables.framework.diConfig );
+									structDelete( cfg, 'loadListener' );
+								}
+								cfg.noClojure = true;
+								var ioc = new "#diComponent#"( subLocations, cfg );
+								ioc.setParent( getDefaultBeanFactory() );
+								setSubsystemBeanFactory( subsystem, ioc );
+							}
+						}
+					}
 
-                internalFrameworkTrace( 'setupSubsystem() called', subsystem );
-                setupSubsystem( subsystem );
-            }
+					internalFrameworkTrace( 'setupSubsystem() called', subsystem );
+					setupSubsystem( subsystem );
+				}
+			}
         }
     }
 

--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -2990,53 +2990,53 @@ component {
     private void function setupSubsystemWrapper( string subsystem ) {
         if ( !len( subsystem ) ) return;
         if ( !isSubsystemInitialized( subsystem ) ) {       
-			lock name="fw1_#application.applicationName#_#variables.framework.applicationKey#_subsysteminit_#subsystem#" type="exclusive" timeout="30" {
-				if ( !isSubsystemInitialized( subsystem ) ) {
-					getFw1App().subsystems[ subsystem ] = now();
-					// Application.cfc does not get a subsystem bean factory!
-					if ( subsystem != variables.magicApplicationSubsystem ) {
-						var subsystemConfig = getSubsystemConfig( subsystem );
-						var diEngine = structKeyExists( subsystemConfig, 'diEngine' ) ? subsystemConfig.diEngine : variables.framework.diEngine;
-						if ( diEngine == "di1" || diEngine == "aop1" ) {
-							// we can only reliably automate D/I engine setup for DI/1 / AOP/1
-							var diLocations = structKeyExists( subsystemConfig, 'diLocations' ) ? subsystemConfig.diLocations : variables.framework.diLocations;
-							var locations = isSimpleValue( diLocations ) ? listToArray( diLocations ) : diLocations;
-							var subLocations = "";
-							for ( var loc in locations ) {
-								var relLoc = trim( loc );
-								// make a relative location:
-								if ( len( relLoc ) > 2 && left( relLoc, 2 ) == "./" ) {
-									relLoc = right( relLoc, len( relLoc ) - 2 );
-								} else if ( len( relLoc ) > 1 && left( relLoc, 1 ) == "/" ) {
-									relLoc = right( relLoc, len( relLoc ) - 1 );
-								}
-								if ( usingSubsystems() ) {
-									subLocations = listAppend( subLocations, variables.framework.base & subsystem & "/" & relLoc );
-								} else {
-									subLocations = listAppend( subLocations, variables.framework.base & variables.framework.subsystemsFolder & "/" & subsystem & "/" & relLoc );
-								}
-							}
-							if ( len( sublocations ) ) {
-								var diComponent = structKeyExists( subsystemConfig, 'diComponent' ) ? subsystemConfig : variables.framework.diComponent;
-								var cfg = { };
-								if ( structKeyExists( subsystemConfig, 'diConfig' ) ) {
-									cfg = subsystemConfig.diConfig;
-								} else {
-									cfg = structCopy( variables.framework.diConfig );
-									structDelete( cfg, 'loadListener' );
-								}
-								cfg.noClojure = true;
-								var ioc = new "#diComponent#"( subLocations, cfg );
-								ioc.setParent( getDefaultBeanFactory() );
-								setSubsystemBeanFactory( subsystem, ioc );
-							}
-						}
-					}
+            lock name="fw1_#application.applicationName#_#variables.framework.applicationKey#_subsysteminit_#subsystem#" type="exclusive" timeout="30" {
+                if ( !isSubsystemInitialized( subsystem ) ) {
+                    getFw1App().subsystems[ subsystem ] = now();
+                    // Application.cfc does not get a subsystem bean factory!
+                    if ( subsystem != variables.magicApplicationSubsystem ) {
+                        var subsystemConfig = getSubsystemConfig( subsystem );
+                        var diEngine = structKeyExists( subsystemConfig, 'diEngine' ) ? subsystemConfig.diEngine : variables.framework.diEngine;
+                        if ( diEngine == "di1" || diEngine == "aop1" ) {
+                            // we can only reliably automate D/I engine setup for DI/1 / AOP/1
+                            var diLocations = structKeyExists( subsystemConfig, 'diLocations' ) ? subsystemConfig.diLocations : variables.framework.diLocations;
+                            var locations = isSimpleValue( diLocations ) ? listToArray( diLocations ) : diLocations;
+                            var subLocations = "";
+                            for ( var loc in locations ) {
+                                var relLoc = trim( loc );
+                                // make a relative location:
+                                if ( len( relLoc ) > 2 && left( relLoc, 2 ) == "./" ) {
+                                    relLoc = right( relLoc, len( relLoc ) - 2 );
+                                } else if ( len( relLoc ) > 1 && left( relLoc, 1 ) == "/" ) {
+                                    relLoc = right( relLoc, len( relLoc ) - 1 );
+                                }
+                                if ( usingSubsystems() ) {
+                                    subLocations = listAppend( subLocations, variables.framework.base & subsystem & "/" & relLoc );
+                                } else {
+                                    subLocations = listAppend( subLocations, variables.framework.base & variables.framework.subsystemsFolder & "/" & subsystem & "/" & relLoc );
+                                }
+                            }
+                            if ( len( sublocations ) ) {
+                                var diComponent = structKeyExists( subsystemConfig, 'diComponent' ) ? subsystemConfig : variables.framework.diComponent;
+                                var cfg = { };
+                                if ( structKeyExists( subsystemConfig, 'diConfig' ) ) {
+                                    cfg = subsystemConfig.diConfig;
+                                } else {
+                                    cfg = structCopy( variables.framework.diConfig );
+                                    structDelete( cfg, 'loadListener' );
+                                }
+                                cfg.noClojure = true;
+                                var ioc = new "#diComponent#"( subLocations, cfg );
+                                ioc.setParent( getDefaultBeanFactory() );
+                                setSubsystemBeanFactory( subsystem, ioc );
+                            }
+                        }
+                    }
 
-					internalFrameworkTrace( 'setupSubsystem() called', subsystem );
-					setupSubsystem( subsystem );
-				}
-			}
+                    internalFrameworkTrace( 'setupSubsystem() called', subsystem );
+                    setupSubsystem( subsystem );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Howdy Sean, or FW/1 maintainer!

Please forgive me if my syntax/understanding is limited: I don't deal with CFML directly much anymore. I ended up troubleshooting a timeout request from within one.cfc for our CFML application team.

I'm not sure exactly *how* it happened, but we have a long-running request that's timing out within the setupSubsystemWrapper method, specifically on the lock it creates. Looking at it, I get the impression that this lock is only supposed to exist when initializing the subsystem, but it's actually being created on every request to the subsystem because it lacked a check for initialization before issuing the lock.

The change in the patch attached simply does a `if ( !isSubsystemInitialized( subsystem ) )` before issuing a lock, keeping to the normal double-checked-lock approach that I think was simply overlooked here.

I've tested this patch within an application and verified that this method is now only running once per request (when reloading the FW) and once per FW load (when not).

If I'm way off base, my ego won't be hurt if this PR is completely incorrect: I don't understand the full context of how FW/1 works.