### PR TITLE
Remove locking from framework one global controller retrieval

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1831,18 +1831,21 @@ component {
         var controllersSlash = variables.framework.controllersFolder & '/';
         var controllersDot = variables.framework.controllersFolder & '.';
         // per #310 we no longer cache the Application controller since it is new on each request
-        if ( !structKeyExists( cache.controllers, componentKey ) || section == variables.magicApplicationController ) {
+        if ( section == variables.magicApplicationController ) {
+            if ( hasDefaultBeanFactory() ) {
+                autowire( this, getDefaultBeanFactory() );
+            }
+            return this;
+        }
+        if ( !structKeyExists( cache.controllers, componentKey ) ) {
             lock name="fw1_#application.applicationName#_#variables.framework.applicationKey#_#componentKey#" type="exclusive" timeout="30" {
-                if ( !structKeyExists( cache.controllers, componentKey ) || section == variables.magicApplicationController ) {
+                if ( !structKeyExists( cache.controllers, componentKey ) ) {
                     if ( hasSubsystemBeanFactory( subsystem ) && getSubsystemBeanFactory( subsystem ).containsBean( beanName ) ) {
                         cfc = getSubsystemBeanFactory( subsystem ).getBean( beanName );
                     } else if ( !usingSubsystems() && hasDefaultBeanFactory() && getDefaultBeanFactory().containsBean( beanName ) ) {
                         cfc = getDefaultBeanFactory().getBean( beanName );
                     } else {
-                        if ( section == variables.magicApplicationController ) {
-                            // treat this (Application.cfc) as a controller:
-                            cfc = this;
-                        } else if ( cachedFileExists( cfcFilePath( request.cfcbase ) & subsystemDir & controllersSlash & section & '.cfc' ) ) {
+                        if ( cachedFileExists( cfcFilePath( request.cfcbase ) & subsystemDir & controllersSlash & section & '.cfc' ) ) {
                             // we call createObject() rather than new so we can control initialization:
                             if ( request.cfcbase == '' ) {
                                 cfc = createObject( 'component', subsystemDot & controllersDot & section );


### PR DESCRIPTION
As it stands right now, every single request that comes in has to acquire the exclusive lock for the global fw1 app controller (i.e. `one.cfc` itself). There is also a race condition since each request sets its instance of `one.cfc` into the application scope via the cache (`cache.controllers[ componentKey ] = cfc;`) and returns the cfc from the cache; it is possible that concurrent requests could overwrite the cache resulting in one of the requests returning the other request's instance of `one.cfc`. (I do doubt this would have consequences, but it is possible.)

This change pulls the Application controller retrieval out of the locking mechanism, which it does not need since every request has its own instance and the application scope controller cache is not (supposed) to be involved. I retained the `autowire` call, but not `injectFramework( cfc );`  since that would result in injecting `one.cfc` into itself; I could add this back to ensure the behavior remains exactly the same. (Also note that the subsystem bean factory check can be ignored since Application.cfc does not get a subsystem bean factory.)