### PR TITLE
Fixes PreserveKey not being passed from a redirect (#522)

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1893,7 +1893,7 @@ component {
         var nextPreserveKey = '';
         var oldKeyToPurge = '';
         try {
-            sessionLock(function(){
+            sessionLock(function() localmode = "classic" {
                 if ( variables.framework.maxNumContextsPreserved > 1 ) {
                     sessionDefault( '__fw1NextPreserveKey', 1 );
                     nextPreserveKey = sessionRead( '__fw1NextPreserveKey' );
@@ -2992,7 +2992,7 @@ component {
 
     private void function setupSubsystemWrapper( string subsystem ) {
         if ( !len( subsystem ) ) return;
-        if ( !isSubsystemInitialized( subsystem ) ) {       
+        if ( !isSubsystemInitialized( subsystem ) ) {
             lock name="fw1_#application.applicationName#_#variables.framework.applicationKey#_subsysteminit_#subsystem#" type="exclusive" timeout="30" {
                 if ( !isSubsystemInitialized( subsystem ) ) {
                     getFw1App().subsystems[ subsystem ] = now();


### PR DESCRIPTION
This is a duplicate pull request of pull 523 but because I reset my local develop repo, it removed the commit and closed the original pull request. The price I pay for not creating a specific issue branch originally. Sorry about that.

Copied original pull details here...

**Issue:**

In Lucee, `localmode="modern"` is extremely strict with what scopes are referenced/available in the chain. Especially when a function within a function accepts a closure. This makes external local and variables scopes unavailable unless directly passed and returned for further use.

**Fix:**

The committed fix sets `localmode="classic"` in the function expression passed into `sessionLock()` inside of `getNextPreserveKeyAndPurgeOld()`. This allows FW/1's flash context to work as expected, regardless of the number of contexts, in both Lucee and Adobe ColdFusion (since the attribute is simply ignored).

**Note On Alternative Approaches:**

If it's preferred to avoid engine specific mechanics in the code, an alternative approach is to define both the "next" and "old" keys to session variables that are accessible to all levels of the execution chain in `getNextPreserveKeyAndPurgeOld()`.

```
private string function getNextPreserveKeyAndPurgeOld() {
        try {
            sessionLock(function(){
                sessionDefault( '__fw1NextPreserveKey', 0 );
                sessionDefault( '__fw1OldKeyToPurge', '' );
                if ( variables.framework.maxNumContextsPreserved > 1 ) {
                    sessionWrite( '__fw1NextPreserveKey', sessionRead( '__fw1NextPreserveKey' ) + 1 );
                    sessionWrite( '__fw1OldKeyToPurge', sessionRead( '__fw1NextPreserveKey' ) - variables.framework.maxNumContextsPreserved );
                } else {
                    sessionWrite( '__fw1NextPreserveKey', '' );
                    sessionWrite( '__fw1PreserveKey', '' );
                }
            });
            var key = getPreserveKeySessionKey( sessionRead( '__fw1OldKeyToPurge' ) );
            if ( sessionHas( key ) ) {
                sessionDelete( key );
            }
        } catch ( any e ) {
            // ignore - assume session scope is disabled
        }
        return sessionRead( '__fw1NextPreserveKey' );
}
```