### PR TITLE
Prevent self-xss in trace messages

### DIFF
--- a/framework/one.cfc
+++ b/framework/one.cfc
@@ -1803,7 +1803,7 @@ component {
                     writeOutput( '<td style="text-align: center; color: #color#">#ucase(trace.t)#</td>' );
                 }
                 writeOutput( '<td style="border: 0; color: black; #font# font-size: small;padding-left: 5px;" width="10%">#action#</td>' );
-                writeOutput( '<td style="border: 0; color: #color#; #font# font-size: small;">#trace.msg#' );
+                writeOutput( '<td style="border: 0; color: #color#; #font# font-size: small;">#encodeForHTML(trace.msg)#' );
                 if ( structKeyExists( trace, 'v' ) ) {
                     writeOutput( '<br />' );
                     writeDump( var = trace.v, expand = false );


### PR DESCRIPTION
Tracing probably shouldn't be turned on in anyone's production environment, even so, an action containing a malicious payload such as `'>"<svg/onload=confirm('xss!')>.index'` will execute when the trace is rendered on a page. I didn't see signs of other properties being affected, but it's possible. Don't know how likely it is that this would be exploited in a real world scenario, but encoding doesn't hurt.